### PR TITLE
Fixed mutex copy in rpc.go (from go vet).

### DIFF
--- a/rpc.go
+++ b/rpc.go
@@ -9,11 +9,12 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/ugorji/go/codec"
 	"io"
 	"io/ioutil"
 	"net/rpc"
 	"sync"
+
+	"github.com/ugorji/go/codec"
 )
 
 // -------------------------------------
@@ -38,11 +39,11 @@ func (c *rpcCodec) encodeToBytes(obj interface{}) []byte {
 	return b
 }
 
-func newRPCCodec(conn io.ReadWriteCloser, h codec.Handle) rpcCodec {
+func newRPCCodec(conn io.ReadWriteCloser, h codec.Handle) *rpcCodec {
 	bw := bufio.NewWriter(conn)
 	br := bufio.NewReader(conn)
 	bb := new(bytes.Buffer)
-	return rpcCodec{
+	return &rpcCodec{
 		rwc:     conn,
 		bw:      bw,
 		br:      br,
@@ -100,7 +101,7 @@ func (c *rpcCodec) ReadResponseBody(body interface{}) error {
 //--------------------------------------------------
 
 type msgpackSpecRpcCodec struct {
-	rpcCodec
+	*rpcCodec
 	framed bool
 }
 

--- a/rpc2/example/client.go
+++ b/rpc2/example/client.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/maxtaco/go-framed-msgpack-rpc/rpc2"
 	"net"
+
+	"github.com/maxtaco/go-framed-msgpack-rpc/rpc2"
 )
 
 type GenericClient interface {
@@ -37,7 +38,7 @@ func (s *Client) Run() (err error) {
 		return
 	}
 
-	xp := rpc2.NewTransport(c, nil)
+	xp := rpc2.NewTransport(c, nil, nil)
 	cli := ArithClient{rpc2.NewClient(xp, nil)}
 
 	for A := 10; A < 23; A += 2 {

--- a/rpc2/example/server.go
+++ b/rpc2/example/server.go
@@ -3,8 +3,9 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/maxtaco/go-framed-msgpack-rpc/rpc2"
 	"net"
+
+	"github.com/maxtaco/go-framed-msgpack-rpc/rpc2"
 )
 
 type Server struct {
@@ -91,7 +92,7 @@ func (s *Server) Run() (err error) {
 		if c, err = listener.Accept(); err != nil {
 			return
 		}
-		xp := rpc2.NewTransport(c, lf)
+		xp := rpc2.NewTransport(c, lf, nil)
 		srv := rpc2.NewServer(xp, nil)
 		srv.Register(ArithProtocol(&ArithServer{c}))
 		srv.Run(true)

--- a/rpc2/packetizer.go
+++ b/rpc2/packetizer.go
@@ -1,7 +1,5 @@
 package rpc2
 
-import ()
-
 type Packetizer struct {
 	dispatch  Dispatcher
 	transport Transporter
@@ -38,7 +36,7 @@ func (p *Packetizer) getMessage(l int) (err error) {
 	nb := int(b)
 
 	if nb >= 0x91 && nb <= 0x9f {
-		err = p.dispatch.Dispatch(Message{p.transport, (nb - 0x90), 0})
+		err = p.dispatch.Dispatch(&Message{p.transport, (nb - 0x90), 0})
 	} else {
 		err = NewPacketizerError("wrong message structure prefix (%d)", nb)
 	}


### PR DESCRIPTION
In dispatch, changed order of encode and register, but this might have already been fixed.

I'd definitely merge the rpc.go change. 
The dispatch.go change can probably be ignored.  The lock was different in the testing I was doing.
I do think it makes sense to register before encode, though...