### PR TITLE
Allow a way to specify codec for transport.

### DIFF
--- a/rpc2/transport.go
+++ b/rpc2/transport.go
@@ -88,13 +88,17 @@ func (t *Transport) GetRemoteAddr() (ret net.Addr) {
 
 func NewTransport(c net.Conn, l LogFactory, wef WrapErrorFunc) *Transport {
 	mh := codec.MsgpackHandle{WriteExt: true}
+	return NewTransportWithCodec(c, &mh, l, wef)
+}
+
+func NewTransportWithCodec(c net.Conn, mh *codec.MsgpackHandle, l LogFactory, wef WrapErrorFunc) *Transport {
 
 	buf := new(bytes.Buffer)
 	ret := &Transport{
-		mh:        &mh,
-		cpkg:      NewConPackage(c, &mh),
+		mh:        mh,
+		cpkg:      NewConPackage(c, mh),
 		buf:       buf,
-		enc:       codec.NewEncoder(buf, &mh),
+		enc:       codec.NewEncoder(buf, mh),
 		mutex:     new(sync.Mutex),
 		rdlck:     new(sync.Mutex),
 		wrlck:     new(sync.Mutex),


### PR DESCRIPTION
This is for supporting using convert/update for extensions. That patch is here: https://github.com/ugorji/go/pull/82