### PR TITLE
Use Transporter interface for client instead of Transport struct

### DIFF
--- a/rpc2/client.go
+++ b/rpc2/client.go
@@ -1,13 +1,11 @@
 package rpc2
 
-import ()
-
 type Client struct {
-	xp          *Transport
+	xp          Transporter
 	unwrapError UnwrapErrorFunc
 }
 
-func NewClient(xp *Transport, f UnwrapErrorFunc) *Client {
+func NewClient(xp Transporter, f UnwrapErrorFunc) *Client {
 	return &Client{xp, f}
 }
 


### PR DESCRIPTION
This allows custom transports (non-Transport) to work.

I tested this with keybase stuff and is a-OK.